### PR TITLE
Errors preventing databases from being created

### DIFF
--- a/02_energy_ade/CREATE_DB_Energy_ADE.sh
+++ b/02_energy_ade/CREATE_DB_Energy_ADE.sh
@@ -3,11 +3,11 @@
 # on PostgreSQL/PostGIS
 
 # Provide your database details here
-export PGPORT=write here the port of the postgres server (e.g. 5432)
-export PGHOST=write here the name/address of the host (e.g. localhost)
-export PGUSER=write here the postgres user (e.g. postgres)
-export CITYDB=write here the name of the database (e.g. vienna)
-export PGBIN =write here the path to psql
+export PGPORT=5432
+export PGHOST=localhost
+export PGUSER=user
+export CITYDB=unade_3dcitydb
+export PGBIN=/usr/bin
 
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null

--- a/02_energy_ade/CREATE_DB_Energy_ADE.sh
+++ b/02_energy_ade/CREATE_DB_Energy_ADE.sh
@@ -3,11 +3,11 @@
 # on PostgreSQL/PostGIS
 
 # Provide your database details here
-export PGPORT=5432
-export PGHOST=localhost
-export PGUSER=user
-export CITYDB=unade_3dcitydb
-export PGBIN=/usr/bin
+export PGPORT=write here the port of the postgres server (e.g. 5432)
+export PGHOST=write here the name/address of the host (e.g. localhost)
+export PGUSER=write here the postgres user (e.g. postgres)
+export CITYDB=write here the name of the database (e.g. vienna)
+export PGBIN=write here the path to psql
 
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null

--- a/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
+++ b/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
@@ -877,7 +877,7 @@ END;
 $$ LANGUAGE 'plpgsql';
 
 ----------------------------------------------------------------
--- Function UTN9_INSERT_NETWORK_TO_NETWORK_FEATURE
+-- Function #UTN9_INSERT_NETWORK_TO_NETWORK_FEATURE
 ----------------------------------------------------------------
 -- DROP FUNCTION IF EXISTS citydb_pkg.utn9_insert_network_to_network_feature (integer, integer) CASCADE;
 CREATE OR REPLACE FUNCTION citydb_pkg.utn9_insert_network_to_network_feature (
@@ -906,7 +906,7 @@ p_network_id,
 p_network_feature_id
 );
 EXCEPTION
-	WHEN OTHERS THEN RAISE NOTICE 'citydb_pkg.utn9_insert_network_to_network_feature (network_id: %, network_feature_id: %): %', network_id, network_feature_id SQLERRM;
+	WHEN OTHERS THEN RAISE NOTICE 'citydb_pkg.utn9_insert_network_to_network_feature (network_id: %, network_feature_id: %): %', network_id, network_feature_id, SQLERRM;
 END;
 $$ LANGUAGE 'plpgsql';
 
@@ -1138,7 +1138,7 @@ p_comm_class_parent_id,
 p_comm_class_id
 ) ;
 EXCEPTION
-	WHEN OTHERS THEN RAISE NOTICE 'citydb_pkg.utn9_insert_comm_class_to_comm_class (comm_class_parent_id: %, comm_class_id): %', comm_class_parent_id, comm_class_id, SQLERRM;
+	WHEN OTHERS THEN RAISE NOTICE 'citydb_pkg.utn9_insert_comm_class_to_comm_class (comm_class_parent_id: %, comm_class_id: %): %', comm_class_parent_id, comm_class_id, SQLERRM;
 END;
 $$ LANGUAGE 'plpgsql';
 

--- a/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
+++ b/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
@@ -877,7 +877,7 @@ END;
 $$ LANGUAGE 'plpgsql';
 
 ----------------------------------------------------------------
--- Function #UTN9_INSERT_NETWORK_TO_NETWORK_FEATURE
+-- Function UTN9_INSERT_NETWORK_TO_NETWORK_FEATURE
 ----------------------------------------------------------------
 -- DROP FUNCTION IF EXISTS citydb_pkg.utn9_insert_network_to_network_feature (integer, integer) CASCADE;
 CREATE OR REPLACE FUNCTION citydb_pkg.utn9_insert_network_to_network_feature (


### PR DESCRIPTION
When trying to create databases, I came across a couple or errors that were preventing the databases from being created properly.  A stray space character was in the Energy ADE config parameters, and there were some issues with some of the string formattings in the DML Functions sql file for utility network ADE.

I was able to create the tables after fixing them here.

Reference: #dec6275


