### PR TITLE
changed definition of citydb_pkg.utn9_delete_network_feature to corre…

### DIFF
--- a/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
+++ b/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
@@ -156,7 +156,7 @@ EXECUTE format('SELECT citydb_pkg.utn9_delete_network_feature(id, %L) FROM %I.ut
 
 -- Delete the depending hollow_spaces(s)
 EXECUTE format('SELECT id FROM %I.utn9_hollow_space WHERE ntw_feature_id=%L', schema_name, o_id) INTO hs_id;
-EXECUTE 'SELECT citydb_pkg.utn9_delete_hollow_space($1, $2)' USING schema_name, hs_id;
+EXECUTE 'SELECT citydb_pkg.utn9_delete_hollow_space($1, $2)' USING hs_id, schema_name;
 
 -- No need to delete reference to material (on delete cascade in m:n table)
 -- No need to delete reference to network (on delete cascade in m:n table)
@@ -164,7 +164,7 @@ EXECUTE 'SELECT citydb_pkg.utn9_delete_hollow_space($1, $2)' USING schema_name, 
 -- Delete the depending feature_graph (topology)
 EXECUTE format('SELECT id FROM %I.utn9_feature_graph WHERE ntw_feature_id=%L', schema_name, o_id) INTO fg_id;
 IF fg_id IS NOT NULL THEN
-  EXECUTE 'SELECT citydb_pkg.utn9_delete_feature_graph($1, $2)' USING schema_name, fg_id;
+  EXECUTE 'SELECT citydb_pkg.utn9_delete_feature_graph($1, $2)' USING fg_id, schema_name;
 END IF;
 
 -- Delete the network_feature itself


### PR DESCRIPTION
…ct parameter signature mismatch that was preventing the deletion of RoundPipes

I was able to get RoundPipe features added after the last fix, but there is a new problem with how `utn9_delete_ntw_feat_distrib_elem_pipe_round()` works.  The cascading function calls eventually lead to a function being called with an incorrect parameter signature:

`utn9_delete_ntw_feat_distrib_elem_pipe_round(id intenger)` calls `citydb_pkg.utn9_delete_network_feature(id integer, varchar schema_name`, which then at line 44 calls `EXECUTE 'SELECT citydb_pkg.utn9_delete_hollow_space($1, $2)' USING schema_name, hs_id;`, which does not match the defined parameter signature of `citydb_pkg.utn9_delete_hollow_space(integer, varchar)`.

Further to this, I believe that there will be a second issue at line 52, where `EXECUTE 'SELECT citydb_pkg.utn9_delete_feature_graph($1, $2)' USING schema_name, fg_id;` is potentially called, given the satisfaction of the condition `IF fg_id IS NOT NULL`, due to the same parameter signature mismatch: `citydb_pkg.utn9_delete_feature_graph(integer, varchar)`

I tested this modification with a freshly-initialized DB and i was able to successfully remove the pipes.