### PR TITLE
fixed function_of_line not updating in citydb_pkg.insert_distrib_element()

### DIFF
--- a/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
+++ b/03_utility_network_ade/postgresql/02_UtilityNetwork_ADE_DML_FUNCTIONS.sql
@@ -764,6 +764,7 @@ AS $$
 DECLARE
   p_id integer := id;
   p_objectclass_id integer := objectclass_id;
+  p_function_of_line varchar := function_of_line;
   p_is_gravity numeric := is_gravity;
   p_is_transmission numeric := is_transmission;
   p_is_communication   numeric := is_communication;
@@ -793,6 +794,7 @@ EXECUTE format('
 INSERT INTO %I.utn9_distrib_element (
  id,
  objectclass_id,
+ function_of_line,
  is_gravity,
  is_transmission,
  is_communication,
@@ -815,11 +817,12 @@ INSERT INTO %I.utn9_distrib_element (
  slope_range_unit,
  profile_name
 ) VALUES (
-%L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L
+%L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L, %L
 ) RETURNING id',
 p_schema_name,
 p_id, 
 p_objectclass_id, 
+p_function_of_line,
 p_is_gravity, 
 p_is_transmission, 
 p_is_communication, 


### PR DESCRIPTION
I noticed that when inserting a `RoundPipe` element, the `function_of_line` field was not updating.  Going deeper, I noticed that `citydb_pkg.insert_distrib_element()` was at no point propagating the value forward to be inserted.

Test query:

```
SELECT citydb_view.utn9_insert_ntw_feat_distrib_elem_pipe_round(
    function_of_line := 'flowLine'
);
```

Running this query pre-fix should show that `function_of_line` is empty.  Running it post-fix should show it updating properly.