### PR TITLE
 fixed typo in objectclass table definition (ConstrollerDevice -> ControllerDevice)

### DIFF
--- a/03_utility_network_ade/postgresql/05_UtilityNetwork_ADE_TABLE_DATA.sql
+++ b/03_utility_network_ade/postgresql/05_UtilityNetwork_ADE_TABLE_DATA.sql
@@ -114,7 +114,7 @@ INSERT INTO citydb.objectclass (id, superclass_id, baseclass_id, is_ade_class, c
 (347, 346, 3, 1, 'StorageDevice'                 , 'ntw9_network_feature'     ),
 (348, 346, 3, 1, 'TechDevice'                    , 'ntw9_network_feature'     ),
 (349, 346, 3, 1, 'MeasurementDevice'             , 'ntw9_network_feature'     ),
-(350, 346, 3, 1, 'ConstrollerDevice'             , 'ntw9_network_feature'     ),
+(350, 346, 3, 1, 'ControllerDevice'              , 'ntw9_network_feature'     ),
 (351, 346, 3, 1, 'AnyDevice'                     , 'ntw9_network_feature'     ),
 -- MediumSupply
 (352,   1, 1, 1, '_MediumSupply'                 , 'ntw9_medium_supply'       ),


### PR DESCRIPTION
Typo in the objectclass table definition was causing a failure when trying to import a `ControllerDevice`. I fixed it and tested, works on my end.

Test query:

```
SELECT citydb_view.utn9_insert_ntw_feat_device_controller(
    gmlid := 'ButterflyValveID_7aab860b-20a9-11e8-93b0-7824afca2075',
    class := 'valve',
    status := 'inUse',
    geom := ST_GeomFromText('POINT Z (429247.659899995 5444287.21989954 0)',26910)
);
```