### PR TITLE
changed cityobject_id -> conn_cityobject_id in parameter list for cit…

### DIFF
--- a/03_utility_network_ade/postgresql/07_UtilityNetwork_ADE_VIEW_FUNCTIONS.sql
+++ b/03_utility_network_ade/postgresql/07_UtilityNetwork_ADE_VIEW_FUNCTIONS.sql
@@ -5673,7 +5673,7 @@ CREATE OR REPLACE FUNCTION citydb_view.utn9_insert_ntw_feat_distrib_elem_pipe_ro
   status                varchar  DEFAULT NULL,
   location_quality      varchar  DEFAULT NULL,
   elevation_quality     varchar  DEFAULT NULL,
-  cityobject_id         integer  DEFAULT NULL,
+  conn_cityobject_id    integer  DEFAULT NULL,
   prot_element_id       integer  DEFAULT NULL,
   geom                  geometry DEFAULT NULL,	
 --


### PR DESCRIPTION
…ydb_view.insert_ntw_feat_distrib_elem_pipe_round

Was impossible to insert a roundpipe due to a variable name mismatch error,